### PR TITLE
Add dronefile and make release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,14 @@
 pipeline:
+  build-base-image:
+    image: plugins/docker
+    when:
+      event: push
+    repo: registry.usw.co/cloud/amazon-ssm-agent-base
+    tags:
+      - ${DRONE_COMMIT_SHA}
+      - latest
   build:
-    image: golang:1.15
+    image: registry.usw.co/cloud/amazon-ssm-agent-base
     environment:
       - GO111MODULE=on
     commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,14 +1,37 @@
 pipeline:
   build-base-image:
+    when:
+      event: [push, tag]
     image: plugins/docker
     repo: registry.usw.co/cloud/amazon-ssm-agent-base
     tags:
       - ${DRONE_COMMIT_SHA}
       - latest
+  build-base-image-tagged:
+    when:
+      event: tag
+      branch: master
+    image: plugins/docker
+    repo: registry.usw.co/cloud/amazon-ssm-agent-base
+    tags:
+      - ${DRONE_TAG}
+      - latest
   build:
+    when:
+      event: [push, tag]
     image: registry.usw.co/cloud/amazon-ssm-agent-base
     commands:
-      - ls
-      - pwd
-      - echo $HOME 
+      - TAG=$(echo ${DRONE_TAG} | sed 's/v//')
+      - git checkout ${TAG}
       - make build-linux
+  publish-tagged:
+    when:
+      event: tag
+      branch: master
+    image: plugins/s3
+    acl: public-read
+    region: "eu-west-1"
+    bucket: "uswitch-tools"
+    strip_prefix: bin/
+    source: bin/*
+    target: amazon-ssm-agent/${DRONE_TAG}

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,7 @@
+pipeline:
+  build:
+    image: golang:1.15
+    environment:
+      - GO111MODULE=on
+    commands:
+      - make build-linux

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,15 +1,14 @@
 pipeline:
   build-base-image:
     image: plugins/docker
-    when:
-      event: push
     repo: registry.usw.co/cloud/amazon-ssm-agent-base
     tags:
       - ${DRONE_COMMIT_SHA}
       - latest
   build:
     image: registry.usw.co/cloud/amazon-ssm-agent-base
-    environment:
-      - GO111MODULE=on
     commands:
+      - ls
+      - pwd
+      - echo $HOME 
       - make build-linux


### PR DESCRIPTION
With this PR, 
* we are setting up a drone for this repo & we will create our own tags with prefix `v` to latest tags, for example for upstream `3.0.755.0` we will create `v3.0.755.0` as first release
* we will be using `uswitch-tools` to store the binaries
* Once this PR is merged, I'll create a tag and publish it to s3 `v3.0.755.0` 
* once we have published the binaries, we can then update the AMIs to utilise SSM agent