### PR TITLE
Fixed tag & s3 upload

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,17 +21,14 @@ pipeline:
       event: [push, tag]
     image: registry.usw.co/cloud/amazon-ssm-agent-base
     commands:
-      - TAG=$(echo ${DRONE_TAG} | sed 's/v//')
-      - git checkout ${TAG}
       - make build-linux
   publish-tagged:
     when:
       event: tag
-      branch: mainline
     image: plugins/s3
     acl: public-read
     region: "eu-west-1"
     bucket: "uswitch-tools"
     strip_prefix: bin/
-    source: bin/*
+    source: bin/**/*
     target: amazon-ssm-agent/${DRONE_TAG}


### PR DESCRIPTION
With this changes, in case we want to generate binaries for newer version:

* we will checkout to newer tag

```
git checkout 3.0.755.0
```

* tag it with prefix `v`

```
git tag v3.0.755.0
```

* push the tag

```
git push origin v3.0.755.0
```

after this, it will upload the binaries and required files in `uswitch-tools` bucket 